### PR TITLE
Correctly resole ROOT

### DIFF
--- a/lib/fastlane/plugin/cryptex.rb
+++ b/lib/fastlane/plugin/cryptex.rb
@@ -1,7 +1,7 @@
 
 module Fastlane
   module Cryptex
-    ROOT = Pathname.new(File.expand_path('lib/fastlane/plugin/cryptex'))
+    ROOT = Pathname.new(File.expand_path('../cryptex', __FILE__))
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
       Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]


### PR DESCRIPTION
```
$ bundler exec cryptex init

Looking for related GitHub issues on fastlane/fastlane...

Found no similar issues. To create a new issue, please visit:
https://github.com/fastlane/fastlane/issues/new
Run `fastlane env` to append the fastlane environment to your issue
/Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/lib/fastlane/plugin/cryptex/setup.rb:5:in `read': [!] No such file or directory @ rb_sysopen - /Users/lacostej/Code/WWTK/fastlane_cryptex/lib/fastlane/plugin/cryptex/assets/CryptexfileTemplate (Errno::ENOENT)
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/lib/fastlane/plugin/cryptex/setup.rb:5:in `run'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/lib/fastlane/plugin/cryptex/commands_generator.rb:52:in `block (2 levels) in run'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/commander-4.4.2/lib/commander/command.rb:178:in `call'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/commander-4.4.2/lib/commander/command.rb:178:in `call'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/commander-4.4.2/lib/commander/command.rb:153:in `run'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/commander-4.4.2/lib/commander/runner.rb:446:in `run_active_command'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-2.2.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/commander-4.4.2/lib/commander/delegates.rb:15:in `run!'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/lib/fastlane/plugin/cryptex/commands_generator.rb:88:in `run'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/lib/fastlane/plugin/cryptex/commands_generator.rb:12:in `start'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/gems/fastlane-plugin-cryptex-0.1.1/bin/cryptex:7:in `<top (required)>'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/bin/cryptex:22:in `load'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/bin/cryptex:22:in `<main>'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `eval'
	from /Users/lacostej/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `<main>'
```