### PR TITLE
Bump keystore expiry to 10000 days

### DIFF
--- a/lib/fastlane/plugin/cryptex/actions/cryptex_generate_keystore.rb
+++ b/lib/fastlane/plugin/cryptex/actions/cryptex_generate_keystore.rb
@@ -3,7 +3,7 @@ module Fastlane
     class CryptexGenerateKeystoreAction < Action
       def self.run(params)
         require "fileutils"
-        cmd = "keytool -genkey -v -keystore #{File.expand_path(params[:destination])} -storepass #{params[:password]} -keypass #{params[:password]} -alias #{params[:alias]} -dname 'CN=#{params[:fullname]},L=#{params[:city]}' -validity 1000"
+        cmd = "keytool -genkey -v -keystore #{File.expand_path(params[:destination])} -storepass #{params[:password]} -keypass #{params[:password]} -alias #{params[:alias]} -dname 'CN=#{params[:fullname]},L=#{params[:city]}' -validity 10000"
         FastlaneCore::CommandExecutor.execute(command: cmd,
                                             print_all: true,
                                         print_command: true)


### PR DESCRIPTION
First of all. Thanks for this fastlane plugin. I am new to both fastlane and Android development but I think it provides a great way to handle keystores.

This PR reflects a recent experience of mine:

If you try to upload an APK signed using the generated keystore to Google Play you get an error saying that the certificate expires too soon.

Bump the expiry date to 10000. This expiry date is taken from [the React Native APK signing guide](https://facebook.github.io/react-native/docs/signed-apk-android.html#generating-a-signing-key).