### PR TITLE
Add short pause if temp file is not present

### DIFF
--- a/lib/fastlane/plugin/cryptex/encrypt.rb
+++ b/lib/fastlane/plugin/cryptex/encrypt.rb
@@ -91,6 +91,8 @@ module Fastlane
         success = system(command.join(' '))
 
         UI.crash!("Error decrypting '#{path}'") unless success
+        # On some filesystems the file is not immediately available after the command finished
+        sleep 0.1 unless File.exist?(tmpfile)
         FileUtils.mv(tmpfile, path)
       end
     end


### PR DESCRIPTION
On an EXT4 filesystem, the temporary file was not found immediately after the openssl command had completed, if the file cannot be found then a short sleep is tried.